### PR TITLE
Upgrade to rugged ~> v0.24.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
-
 language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+sudo: false
+before_install:
+  - gem install bundler
 script:
   - bundle exec rspec spec
   - bundle exec cucumber

--- a/lib/ppl/adapter/storage/git.rb
+++ b/lib/ppl/adapter/storage/git.rb
@@ -24,7 +24,7 @@ class Ppl::Adapter::Storage::Git < Ppl::Adapter::Storage
   def load_address_book
     address_book = Ppl::Entity::AddressBook.new
 
-    head = @repository.lookup(@repository.head.target)
+    head = @repository.lookup(@repository.head.target.oid)
     head.tree.each do |file|
       extension = file[:name].slice(-4..-1)
       if extension != ".vcf"
@@ -77,7 +77,7 @@ class Ppl::Adapter::Storage::Git < Ppl::Adapter::Storage
     end
 
     if !head.nil?
-      parents    = [ @repository.lookup( @repository.head.target ).oid ]
+      parents    = [ @repository.lookup( @repository.head.target.oid ).oid ]
       update_ref = "HEAD"
     else
       parents    = []
@@ -118,7 +118,8 @@ class Ppl::Adapter::Storage::Git < Ppl::Adapter::Storage
   def read_contact_from_disk(id)
     filename = id + ".vcf"
     target   = @repository.head.target
-    vcard    = @repository.file_at(target, filename)
+    blob     = @repository.blob_at(target.oid, filename)
+    vcard    = blob.nil? ? nil : blob.content
     contact  = nil
 
     if !vcard.nil?

--- a/ppl.gemspec
+++ b/ppl.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("inifile", "2.0.2")
   spec.add_dependency("mail", "2.5.3")
   spec.add_dependency("morphine", "0.1.1")
-  spec.add_dependency("rugged", "0.17.0.b6")
+  spec.add_dependency("rugged", "~> 0.24.0")
   spec.add_dependency("greencard", "0.0.5")
 
   spec.add_development_dependency("cucumber")

--- a/spec/ppl/adapter/email_scraper/mail_spec.rb
+++ b/spec/ppl/adapter/email_scraper/mail_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 
 describe Ppl::Adapter::EmailScraper::Mail do
 


### PR DESCRIPTION
After I ended up with the latest rugged installed on my system ppl would
not run because of the method Repository#file_at was renamed to
Repository#blob_at, along with some modification to the arguments and
returned values.

I have tried to make the smallest number of changes to get the tests
passing with #blob_at.